### PR TITLE
Port get_version from debianize plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 vdt.versionplugin.wheel
 =======================
-
+```
 version --plugin=wheel -B11 --verbose
 DEBUG:vdt.versionplugin.default:Extra argument are []
 DEBUG:vdt.versionplugin.default:Writing version 0.0.2-jenkins-11
@@ -24,4 +24,4 @@ INFO:wheel:adding 'vdt.versionplugin.wheel-0.0.2.jenkins.11.dist-info/zip-safe'
 INFO:wheel:adding 'vdt.versionplugin.wheel-0.0.2.jenkins.11.dist-info/WHEEL'
 INFO:wheel:adding 'vdt.versionplugin.wheel-0.0.2.jenkins.11.dist-info/METADATA'
 INFO:wheel:adding 'vdt.versionplugin.wheel-0.0.2.jenkins.11.dist-info/RECORD'
-
+```

--- a/setup.py
+++ b/setup.py
@@ -3,25 +3,25 @@ from setuptools import find_packages, setup
 
 pkgname = "vdt.versionplugin.wheel"
 
-setup(name=pkgname,
-      version="0.0.6",
-      description="vdt.version plugin for building python wheels.",
-      author="Lars van de Kerkhof",
-      author_email="lars@devopsconsulting.nl",
-      maintainer="Lars van de Kerkhof",
-      maintainer_email="lars@devopsconsulting.nl",
-      packages=find_packages(),
-      include_package_data=True,
-      namespace_packages=['vdt', 'vdt.versionplugin'],
-      zip_safe=True,
-      install_requires=[
-          "setuptools",
-          "vdt.version",
-          "vdt.versionplugin.default",
-          "vdt.versionplugin.debianize",
-          "mock",
-          "wheel",
-          "pip"
-      ],
-      entry_points={},
+setup(
+    name=pkgname,
+    version="0.0.7",
+    description="vdt.version plugin for building python wheels.",
+    author="Lars van de Kerkhof",
+    author_email="lars@devopsconsulting.nl",
+    maintainer="Lars van de Kerkhof",
+    maintainer_email="lars@devopsconsulting.nl",
+    packages=find_packages(),
+    include_package_data=True,
+    namespace_packages=['vdt', 'vdt.versionplugin'],
+    zip_safe=True,
+    install_requires=[
+        "setuptools",
+        "vdt.version",
+        "vdt.versionplugin.default",
+        "mock",
+        "wheel",
+        "pip"
+    ],
+    entry_points={},
 )

--- a/vdt/versionplugin/wheel/__init__.py
+++ b/vdt/versionplugin/wheel/__init__.py
@@ -1,2 +1,2 @@
 from vdt.versionplugin.wheel.package import build_package
-from vdt.versionplugin.debianize.version import get_version
+from vdt.versionplugin.wheel.version import get_version

--- a/vdt/versionplugin/wheel/version.py
+++ b/vdt/versionplugin/wheel/version.py
@@ -1,0 +1,31 @@
+"""
+This file contains only functions that deal with the version
+of the repository. It can set a new version as a tag and look
+up the current version.
+"""
+import subprocess
+import logging
+
+from vdt.version.shared import VersionNotFound, Version
+from vdt.versionplugin.default import get_version as get_git_version
+
+log = logging.getLogger('vdt.versionplugin.wheel.version')
+
+
+__all__ = ('get_version')
+
+
+def get_version(version_args):
+    """
+    Retrieve the version from the repo, if no version tag
+    can be found, read it from the setup script
+
+    It can be assumed that this script will be ran in the
+    root of the repository.
+    """
+    try:
+        return get_git_version(version_args)
+    except VersionNotFound:
+        log.debug('no version tag found, taking version from setup.py')
+        result = subprocess.check_output(['python', 'setup.py', '--version'])
+        return Version(result.decode("utf-8"), extra_args=version_args)


### PR DESCRIPTION
Now both the `wheel` and `debianize` plugins have the same code for `get_version`, which is actually not that bad. It removes the very strange dependency on the debianize plugin for now, and it's not much code after all.